### PR TITLE
[CSP-40] Fix page load time issues

### DIFF
--- a/app/academics/page.tsx
+++ b/app/academics/page.tsx
@@ -71,6 +71,10 @@ export default function Academics() {
 
       <SectionWrapper title="Courses" />
 
+      <p style={{ paddingLeft: "4rem" }}>
+        <b>Note:</b> Only courses that showed up in more than one response were included, otherwise there would be too many courses to display properly.
+      </p>
+
       <ComponentWrapper
         heading="Is your expected graduation date the same as when you enrolled in your current program?"
         bodyText="Even though the vast majority of respondents stayed on track with their initial plans, it is also perfectly normal to deviate from the planned route for a degree. Some students may have either shortened their degree by, for example, removing co-op from their degree or taking more classes than a full course load per term. Meanwhile, others may have delayed their graduation by retaking failed classes, taking gap years, adding minors to their degree, etc. "
@@ -108,6 +112,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -132,6 +137,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -153,6 +159,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -175,6 +182,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -196,6 +204,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -218,6 +227,7 @@ export default function Academics() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={30}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -240,6 +250,7 @@ export default function Academics() {
           wordPadding={8}
           desktopMaxFontSize={60}
           desktopMinFontSize={15}
+          minFrequency={2}
           mobileMaxFontSize={60}
         />
       </ComponentWrapper>
@@ -263,6 +274,7 @@ export default function Academics() {
           wordPadding={11}
           desktopMaxFontSize={80}
           mobileMaxFontSize={70}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -284,6 +296,7 @@ export default function Academics() {
           wordPadding={20}
           desktopMaxFontSize={80}
           mobileMaxFontSize={80}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -379,6 +392,7 @@ export default function Academics() {
           wordPadding={3}
           desktopMaxFontSize={75}
           mobileMaxFontSize={48}
+          minFrequency={2}
         />
       </ComponentWrapper>
 

--- a/app/lifestyle-and-interests/page.tsx
+++ b/app/lifestyle-and-interests/page.tsx
@@ -132,6 +132,7 @@ export default function LifestyleAndInterests() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={48}
+          minFrequency={2}
         />
       </ComponentWrapper>
 
@@ -147,6 +148,7 @@ export default function LifestyleAndInterests() {
           wordPadding={7}
           desktopMaxFontSize={75}
           mobileMaxFontSize={48}
+          minFrequency={2}
         />
       </ComponentWrapper>
 

--- a/components/WordCloud.tsx
+++ b/components/WordCloud.tsx
@@ -1,11 +1,13 @@
+"use client";
+
+import { Color } from "@/utils/Color";
+import { inDevEnvironment } from "@/utils/inDevEnviroment";
+import { useIsMobile } from "@/utils/isMobile";
 import { scaleLog } from "@visx/scale";
 import { Text } from "@visx/text";
 import { useTooltip, withTooltip } from "@visx/tooltip";
 import { Wordcloud as VisxWordcloud } from "@visx/wordcloud";
 import React from "react";
-import { Color } from "@/utils/Color";
-import { inDevEnvironment } from "@/utils/inDevEnviroment";
-import { useIsMobile } from "@/utils/isMobile";
 
 import { getTooltipPosition, TooltipWrapper } from "./TooltipWrapper";
 
@@ -37,6 +39,8 @@ interface WordCloudProps {
   spiral?: "rectangular" | "archimedean";
   /** ClassName of the wrapper of the wordcloud */
   className?: string;
+  /** Items that show up less frequently than this will be hidden */
+  minFrequency?: number;
 }
 
 interface WordData {
@@ -62,6 +66,7 @@ export const WordCloud = withTooltip(
     spiral,
     className,
     minWidth,
+    minFrequency,
   }: WordCloudProps) => {
     const { tooltipData, tooltipLeft, tooltipTop, tooltipOpen, showTooltip, hideTooltip } = useTooltip<WordData>();
 
@@ -70,7 +75,7 @@ export const WordCloud = withTooltip(
         <WordCloudWordsMemoized
           width={width}
           height={height}
-          data={data}
+          data={minFrequency ? data.filter((x) => x.value >= minFrequency) : data}
           wordPadding={wordPadding}
           fontWeight={fontWeight}
           desktopMinFontSize={desktopMinFontSize}


### PR DESCRIPTION
Pages like academics currently load very slowly. This change introduces a cut-off for word cloud frequency that is applied strategically to some pages that are overflowing and taking too much time to load.